### PR TITLE
Amend lookup of the reference rate

### DIFF
--- a/src/App/Calculator/Calculation.php
+++ b/src/App/Calculator/Calculation.php
@@ -4,16 +4,18 @@ declare(strict_types=1);
 
 namespace App\Calculator;
 
+use DateTimeImmutable;
 use Money\Money;
 
-final class Calculation
+final readonly class Calculation
 {
     private function __construct(
-        public readonly Request $request,
-        public readonly float $interestRate,
-        public readonly int $recoveryFee,
-        public readonly int $interestPayable,
-        public readonly int $daysOverdue,
+        public Request $request,
+        public float $interestRate,
+        public int $recoveryFee,
+        public int $interestPayable,
+        public int $daysOverdue,
+        public DateTimeImmutable $referenceDate,
     ) {
     }
 
@@ -23,6 +25,7 @@ final class Calculation
         Money $recoveryFee,
         Money $interestPayable,
         int $daysOverdue,
+        DateTimeImmutable $referenceDate,
     ): self {
         return new self(
             $request,
@@ -30,6 +33,7 @@ final class Calculation
             (int) $recoveryFee->getAmount(),
             (int) $interestPayable->getAmount(),
             $daysOverdue,
+            $referenceDate,
         );
     }
 

--- a/src/App/Calculator/StandardCalculator.php
+++ b/src/App/Calculator/StandardCalculator.php
@@ -7,6 +7,7 @@ namespace App\Calculator;
 use App\BaseRate\ChangeList;
 use App\Util\Assert;
 use DateInterval;
+use DateTimeImmutable;
 use Money\Currency;
 use Money\Money;
 
@@ -24,21 +25,23 @@ final readonly class StandardCalculator implements Calculator
 
     public function calculate(Request $request): Calculation
     {
-        $baseRate = $this->rateHistory->findChangeOnOrPreceding($request->dueDate);
+        $terms = new DateInterval(sprintf('P%dD', $request->termsInDays));
+        $dueDate = $request->dueDate->add($terms);
+        $referenceDate = $this->referenceDate($dueDate);
+
+        if ($dueDate >= $request->now) {
+            $zero = new Money(0, $this->expectedCurrency);
+
+            return Calculation::new($request, 0.0, $zero, $zero, 0, $referenceDate);
+        }
+
+        $baseRate = $this->rateHistory->findChangeOnOrPreceding($referenceDate);
         if (! $baseRate) {
             throw CalculationFailed::becauseBaseRateCannotBeFoundOn($request->dueDate);
         }
 
         if (! $request->currency()->equals($this->expectedCurrency)) {
             throw CalculationFailed::becauseCurrencyIsUnsupported($request->currency());
-        }
-
-        $terms = new DateInterval(sprintf('P%dD', $request->termsInDays));
-        $dueDate = $request->dueDate->add($terms);
-        if ($dueDate >= $request->now) {
-            $zero = new Money(0, $this->expectedCurrency);
-
-            return Calculation::new($request, 0.0, $zero, $zero, 0);
         }
 
         $days = $request->now->diff($dueDate)->days;
@@ -49,6 +52,28 @@ final readonly class StandardCalculator implements Calculator
         $dailyAmount = $request->amount()->multiply((string) ($dailyRate / 100));
         $interestAmount = $dailyAmount->multiply($days);
 
-        return Calculation::new($request, $interestRate, $recovery, $interestAmount, $days);
+        return Calculation::new($request, $interestRate, $recovery, $interestAmount, $days, $referenceDate);
+    }
+
+    /**
+     * Find the BoE reference date for the 6-month period in which the debt became due
+     *
+     * @link https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/360834/bis-14-1116-a-users-guide-to-the-recast-late-payment-directive.pdf
+     */
+    private function referenceDate(DateTimeImmutable $dueDate): DateTimeImmutable
+    {
+        if ((int) $dueDate->format('n') <= 6) {
+            return $dueDate->setDate(
+                (int) $dueDate->format('Y') - 1,
+                12,
+                31,
+            );
+        }
+
+        return $dueDate->setDate(
+            (int) $dueDate->format('Y'),
+            6,
+            30,
+        );
     }
 }

--- a/src/App/Middleware/CalculationMiddleware.php
+++ b/src/App/Middleware/CalculationMiddleware.php
@@ -27,13 +27,13 @@ use function is_string;
 use function Psl\Json\decode;
 use function str_contains;
 
-final class CalculationMiddleware implements MiddlewareInterface
+final readonly class CalculationMiddleware implements MiddlewareInterface
 {
     public function __construct(
-        private readonly Calculator $calculator,
-        private readonly CalculationRequestInputFilter $inputFilter,
-        private readonly Currency $currency,
-        private readonly ClockInterface $clock,
+        private Calculator $calculator,
+        private CalculationRequestInputFilter $inputFilter,
+        private Currency $currency,
+        private ClockInterface $clock,
     ) {
     }
 
@@ -112,6 +112,7 @@ final class CalculationMiddleware implements MiddlewareInterface
             'daysOverdue' => $result->daysOverdue,
             'originalAmount' => $formatter->format($result->request->amount()),
             'dueDate' => $result->request->dueDate->format('Y-m-d'),
+            'referenceDate' => $result->referenceDate->format('Y-m-d'),
             'terms' => $result->request->termsInDays,
         ], StatusCodeInterface::STATUS_OK);
     }

--- a/templates/pages/home.phtml
+++ b/templates/pages/home.phtml
@@ -70,7 +70,7 @@ $initialDate = new DateTimeImmutable('-30 days');
                 <li>Days Overdue: <span class="result-daysOverdue"></span></li>
                 <li>Annual Rate: <span class="result-interestRate"></span>%
                     <em>(The statutory rate of 8.0% + The Bank of England base rate as at <span
-                            class="result-dueDate"></span>)</em></li>
+                            class="result-referenceDate"></span>)</em></li>
                 <li>Interest Amount Payable: £<span class="result-interestPayable"></span></li>
                 <li>Recovery Fee: £<span class="result-recoveryFee"></span>
                     <em>(According to the legislation)</em></li>


### PR DESCRIPTION
The BoE "Reference rate" is defined as the rate in effect on the last day of the preceding 6-month period.

The periods are 1st Jan - 30th June  and 1st July - 31st December (inclusive), therefore, a _Due Date_ of July 15th 2023 would use the base rate in effect on 30th June 2023.

Closes #127

This patch fetches the correct reference rate in effect at the time the debt became due/late and updates the response to include the reference date so that it is clear which date is being used to determine the rate in effect.