### PR TITLE
Add X-Frame-Options: SAMEORIGIN to all response payloads.

### DIFF
--- a/config/pipeline.php
+++ b/config/pipeline.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Middleware\XFrameOptionsMiddleware;
 use Laminas\Stratigility\Middleware\ErrorHandler;
 use Mezzio\Application;
 use Mezzio\Handler\NotFoundHandler;
@@ -24,6 +25,7 @@ return static function (Application $app, MiddlewareFactory $factory, ContainerI
     $app->pipe(ImplicitOptionsMiddleware::class);
     $app->pipe(MethodNotAllowedMiddleware::class);
     $app->pipe(UrlHelperMiddleware::class);
+    $app->pipe(XFrameOptionsMiddleware::class);
     $app->pipe(DispatchMiddleware::class);
     $app->pipe(NotFoundHandler::class);
 };

--- a/src/App/ConfigProvider.php
+++ b/src/App/ConfigProvider.php
@@ -48,6 +48,7 @@ final class ConfigProvider
                 Log\ErrorHandlerLoggingListener::class => Log\Container\ErrorHandlerLoggingListenerFactory::class,
                 Middleware\CalculationMiddleware::class => Middleware\Container\CalculationMiddlewareFactory::class,
                 Middleware\TemplateRenderer::class => Middleware\Container\TemplateRendererFactory::class,
+                Middleware\XFrameOptionsMiddleware::class => Laminas\ServiceManager\Factory\InvokableFactory::class,
                 Money\Currency::class => static fn (): Money\Currency => new Money\Currency('GBP'),
                 Psr\Http\Client\ClientInterface::class => Container\HttpClientFactory::class,
 

--- a/src/App/Middleware/XFrameOptionsMiddleware.php
+++ b/src/App/Middleware/XFrameOptionsMiddleware.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Middleware;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final readonly class XFrameOptionsMiddleware implements MiddlewareInterface
+{
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        return $handler->handle($request)->withHeader('X-Frame-Options', 'SAMEORIGIN');
+    }
+}

--- a/test/Unit/Middleware/XFrameOptionsMiddlewareTest.php
+++ b/test/Unit/Middleware/XFrameOptionsMiddlewareTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AppTest\Unit\Middleware;
+
+use App\Middleware\XFrameOptionsMiddleware;
+use AppTest\Unit\Framework\TestCase;
+use AppTest\Unit\Framework\TestHandler;
+use Laminas\Diactoros\Response\HtmlResponse;
+
+class XFrameOptionsMiddlewareTest extends TestCase
+{
+    private XFrameOptionsMiddleware $middleware;
+    private TestHandler $handler;
+
+    protected function setUp(): void
+    {
+        $this->middleware = new XFrameOptionsMiddleware();
+        $this->handler = new TestHandler(new HtmlResponse('Foo'));
+    }
+
+    public function testThatTheResponseWillHaveTheXFrameOptionsHeaderAppended(): void
+    {
+        $response = $this->middleware->process($this->serverRequest('/'), $this->handler);
+
+        self::assertTrue($this->handler->didHandle());
+        self::assertMessageHasHeader($response, 'X-Frame-Options', 'SAMEORIGIN');
+    }
+}


### PR DESCRIPTION
It's pretty shitty to embed someone else's work and pass it off as your own. So this is telling "Elite Customer Solutions" to fuck off.